### PR TITLE
fix: modernize and fix profile assets workflow

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -8,33 +8,33 @@ on:
 jobs:
   update-assets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Ensure assets directory exists
         run: mkdir -p assets
 
       - name: Generate GitHub Stats SVG
-        uses: anuraghazra/github-readme-stats@master
+        uses: readme-tools/github-readme-stats-action@v1
         with:
-          filename: assets/github-stats.svg
+          card: stats
+          path: assets/github-stats.svg
           token: ${{ secrets.GH_PAT }}
-          show_icons: true
-          theme: dracula
-          include_all_commits: true
-          count_private: true
+          options: theme=dracula&show_icons=true&include_all_commits=true&count_private=true
 
       - name: Generate GitHub Trophies SVG
         run: |
           curl -o assets/github-trophies.svg "https://github-profile-trophy.vercel.app/?username=${{ github.repository_owner }}&theme=dracula"
 
       - name: Generate WakaTime SVG
-        uses: anuraghazra/github-readme-stats@master
+        uses: readme-tools/github-readme-stats-action@v1
         with:
-          filename: assets/wakatime.svg
-          api: wakatime
-          wakatime_user: ${{ secrets.WAKATIME_USERNAME }}
-          theme: dracula
+          card: wakatime
+          path: assets/wakatime.svg
+          token: ${{ secrets.GITHUB_TOKEN }}
+          options: username=${{ secrets.WAKATIME_USERNAME }}&theme=dracula
 
       - name: Commit and Push
         run: |


### PR DESCRIPTION
## Summary
- Switched from `anuraghazra/github-readme-stats@master` to `readme-tools/github-readme-stats-action@v1`.
- Updated configuration parameters (`path`, `card`, `options`) to match the new action.
- Added `contents: write` permissions to the job to allow the bot to commit and push.
- Upgraded `actions/checkout` to `v4`.

## Test Plan
- [ ] Manual verification of YAML syntax (verified with `git diff`).
- [ ] Trigger the `workflow_dispatch` manually on GitHub to confirm the action runs successfully.