### PR TITLE
fix: modernize and fix profile assets workflow

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -25,8 +25,11 @@ jobs:
           options: theme=dracula&show_icons=true&include_all_commits=true&count_private=true
 
       - name: Generate GitHub Trophies SVG
-        run: |
-          curl -o assets/github-trophies.svg "https://github-profile-trophy.vercel.app/?username=${{ github.repository_owner }}&theme=dracula"
+        uses: ryo-ma/github-profile-trophy@master
+        with:
+          username: ${{ github.repository_owner }}
+          theme: dracula
+          output_path: assets/github-trophies.svg
 
       - name: Generate WakaTime SVG
         uses: readme-tools/github-readme-stats-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 .npm/
 .pnpm-store/
 .yarn/
+/~/.gemini


### PR DESCRIPTION
## Summary
- Switched from `anuraghazra/github-readme-stats@master` to `readme-tools/github-readme-stats-action@v1`.
- Replaced the broken `curl` command for GitHub Trophies with the `ryo-ma/github-profile-trophy@master` action.
- Updated configuration parameters (`path`, `card`, `options`) to match the new action format.
- Added `contents: write` permissions to the job to allow the bot to commit and push generated SVGs.
- Upgraded `actions/checkout` to `v4`.

## Test Plan
- [ ] Manual verification of YAML syntax.
- [ ] Trigger the `workflow_dispatch` manually on GitHub to confirm the action runs successfully and generates the SVGs in the `assets/` directory.