### PR TITLE
fix: add token input for GitHub Trophies action

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -28,6 +28,7 @@ jobs:
         uses: ryo-ma/github-profile-trophy@master
         with:
           username: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           theme: dracula
           output_path: assets/github-trophies.svg
 


### PR DESCRIPTION
## Summary
- Added the required `token` input (`secrets.GITHUB_TOKEN`) to the `ryo-ma/github-profile-trophy` step.
- This resolves the `401 Unauthorized` error that occurred in the previous workflow run.